### PR TITLE
rename JdbcSinkConnector to ""Demux

### DIFF
--- a/config/sink-quickstart-sqlite.properties
+++ b/config/sink-quickstart-sqlite.properties
@@ -16,7 +16,7 @@
 # The first few settings are required for all connectors:
 # a name, the connector class to run, and the maximum number of tasks to create:
 name=test-sink
-connector.class=io.confluent.connect.jdbc.JdbcSinkConnector
+connector.class=io.confluent.connect.jdbc.JdbcSinkConnectorDemux
 tasks.max=1
 
 # The topics to consume from - required for sink connectors like this one

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnectorDemux.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnectorDemux.java
@@ -29,8 +29,8 @@ import io.confluent.connect.jdbc.sink.JdbcSinkConfig;
 import io.confluent.connect.jdbc.sink.JdbcSinkTask;
 import io.confluent.connect.jdbc.util.Version;
 
-public final class JdbcSinkConnector extends SinkConnector {
-  private static final Logger log = LoggerFactory.getLogger(JdbcSinkConnector.class);
+public final class JdbcSinkConnectorDemux extends SinkConnector {
+  private static final Logger log = LoggerFactory.getLogger(JdbcSinkConnectorDemux.class);
 
   private Map<String, String> configProps;
 


### PR DESCRIPTION
There is already the JdbcSinkConnector installed on my docker instance
by default, so I have renamed my custom plugin to remove ambiguity.